### PR TITLE
add schema design

### DIFF
--- a/Backend/prisma/schema.prisma
+++ b/Backend/prisma/schema.prisma
@@ -1,0 +1,185 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "../generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum UserRole {
+  ADMIN
+  MANAGER
+  EMPLOYEE
+}
+
+// Enums
+enum Role {
+  EMPLOYEE
+  MANAGER
+  ADMIN
+}
+
+enum ExpenseStatus {
+  PENDING
+  IN_PROGRESS
+  APPROVED
+  REJECTED
+}
+
+enum ApprovalStatus {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+enum ApprovalRuleType {
+  SEQUENTIAL
+  PERCENTAGE
+  SPECIFIC_APPROVER
+  HYBRID
+}
+
+model Company {
+  id                     String   @id @default(cuid())
+  name                   String
+  currency               String   @default("USD") // Base currency for the company
+  sequentialApproval     Boolean  @default(false) // If true, approvals must be sequential
+  minimumApprovalPercent Int      @default(50) // Minimum percentage of approvers needed
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  // Relations
+  users      User[]
+  expenses   Expense[]
+  categories ExpenseCategory[]
+  rules      ApprovalRule[]
+
+  @@map("companies")
+}
+
+model User {
+  id           String   @id @default(cuid())
+  email        String   @unique
+  name         String
+  role         Role     @default(EMPLOYEE)
+  companyId    String
+  company      Company  @relation(fields: [companyId], references: [id])
+  isApprover   Boolean  @default(false)
+  approverLevel Int?    // For sequential approval order
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  // Relations
+  expenses         Expense[]
+  approvals        ExpenseApproval[]
+  createdRules     ApprovalRule[]    @relation("CreatedApprovalRules")
+  approvedExpenses ExpenseApproval[] @relation("ApproverExpenses")
+
+  @@map("users")
+}
+
+model ExpenseCategory {
+  id          String    @id @default(uuid())
+  name        String
+  description String?
+  isActive    Boolean   @default(true)
+  companyId   String
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  company     Company   @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  expenses    Expense[]
+
+  @@unique([name, companyId])
+  @@map("expense_categories")
+}
+
+model Expense {
+  id               String           @id @default(cuid())
+  description      String
+  amount           Float
+  originalAmount   Float?
+  originalCurrency String?
+  exchangeRate     Float?
+  currency         String           @default("USD")
+  expenseDate      DateTime
+  receiptUrl       String?
+  merchantName     String?
+  notes            String?
+  ocrData          Json?            // Store OCR extracted data
+  status           ExpenseStatus    @default(PENDING)
+  currentStep      Int              @default(1)
+  totalSteps       Int              @default(1)
+  submittedAt      DateTime?        // When the expense was submitted
+  isReadonly       Boolean          @default(false) // Makes expense readonly after submission
+  userId           String
+  companyId        String
+  categoryId       String?
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
+
+  // Relations
+  user       User              @relation(fields: [userId], references: [id])
+  company    Company           @relation(fields: [companyId], references: [id])
+  category   ExpenseCategory?  @relation(fields: [categoryId], references: [id])
+  approvals  ExpenseApproval[]
+
+  @@map("expenses")
+}
+
+model ExpenseApproval {
+  id         String            @id @default(cuid())
+  expenseId  String
+  approverId String
+  step       Int
+  status     ApprovalStatus    @default(PENDING)
+  comments   String?
+  approvedAt DateTime?
+  rejectedAt DateTime?
+  createdAt  DateTime          @default(now())
+  updatedAt  DateTime          @updatedAt
+
+  // Relations
+  expense  Expense @relation(fields: [expenseId], references: [id])
+  approver User    @relation("ApproverExpenses", fields: [approverId], references: [id])
+  user     User    @relation(fields: [approverId], references: [id], map: "expense_approvals_user_fkey")
+
+  @@unique([expenseId, approverId])
+  @@map("expense_approvals")
+}
+
+model ApprovalRule {
+  id                  String           @id @default(cuid())
+  name                String
+  description         String?
+  minAmount           Float?
+  maxAmount           Float?
+  categoryIds         String[] // Array of category IDs
+  isActive            Boolean          @default(true)
+  companyId           String
+  createdById         String
+  createdAt           DateTime         @default(now())
+  updatedAt           DateTime         @updatedAt
+
+  // Relations
+  company             Company          @relation(fields: [companyId], references: [id])
+  createdBy           User             @relation("CreatedApprovalRules", fields: [createdById], references: [id])
+  steps               ApprovalStep[]
+
+  @@map("approval_rules")
+}
+
+model ApprovalStep {
+  id             String @id @default(uuid())
+  ruleId         String
+  userId         String
+  step           Int
+  createdAt      DateTime @default(now())
+
+  rule           ApprovalRule @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+
+  @@unique([ruleId, step])
+  @@map("approval_steps")
+}


### PR DESCRIPTION
This pull request introduces a comprehensive Prisma schema for the backend, laying the foundation for a company-based expense management and approval system. The schema defines the core data models, enums, and relationships necessary to support users, companies, expenses, categories, approval rules, and multi-step approval workflows.

Key highlights of the changes:

**Database and Generator Configuration**
- Configures the Prisma client generator and sets up a PostgreSQL datasource using an environment variable for the database URL.

**Core Data Models**
- Defines models for `Company`, `User`, `ExpenseCategory`, `Expense`, `ExpenseApproval`, `ApprovalRule`, and `ApprovalStep`, establishing relationships between them to support company-wide expense tracking and approval processes.

**Approval Workflow Support**
- Implements enums and fields to enable sequential, percentage-based, and specific-approver approval flows, including support for multi-step approvals and tracking approval status at each step.

**Role and Status Management**
- Adds enums for user roles (`Role`, `UserRole`), expense statuses (`ExpenseStatus`), approval statuses (`ApprovalStatus`), and approval rule types (`ApprovalRuleType`) to enforce business logic and access control.

**Data Integrity and Constraints**
- Establishes unique constraints, foreign key relationships, and default values to ensure data consistency, such as unique user emails