### PR TITLE
added local docker confing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: expense-management-db
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: expense_managemente_management
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+    driver: local


### PR DESCRIPTION
This pull request introduces a new `docker-compose.yml` file to the project, enabling easy setup and management of a local PostgreSQL database instance using Docker. This addition streamlines development and testing by providing a consistent environment.

Infrastructure setup:

* Added a `docker-compose.yml` file that defines a `postgres` service using the `postgres:16-alpine` image, exposing port 5432, setting up environment variables for the database, and mounting a persistent Docker volume for data storage.
* Configured a healthcheck for the PostgreSQL container to ensure the service is ready before dependent services connect.