### PR TITLE
Kishan vyas

### DIFF
--- a/Backend/.gitignore
+++ b/Backend/.gitignore
@@ -3,3 +3,6 @@ node_modules
 .env
 
 /generated/prisma
+
+# Prisma migrations - exclude from version control
+prisma/migrations/

--- a/Backend/prisma/schema.prisma
+++ b/Backend/prisma/schema.prisma
@@ -4,8 +4,140 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}
+
+model Company {
+  id                     String            @id @default(cuid())
+  name                   String
+  country                String
+  currency               String            @default("USD")
+  sequentialApproval     Boolean           @default(false)
+  minimumApprovalPercent Int               @default(50)
+  createdAt              DateTime          @default(now())
+  updatedAt              DateTime          @updatedAt
+  rules                  ApprovalRule[]
+  categories             ExpenseCategory[]
+  expenses               Expense[]
+  users                  User[]
+
+  @@map("companies")
+}
+
+model User {
+  id               String            @id @default(cuid())
+  email            String            @unique
+  name             String
+  password         String
+  role             Role              @default(EMPLOYEE)
+  companyId        String
+  isApprover       Boolean           @default(false)
+  approverLevel    Int?
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  createdRules     ApprovalRule[]    @relation("CreatedApprovalRules")
+  approvedExpenses ExpenseApproval[] @relation("ApproverExpenses")
+  expenses         Expense[]
+  company          Company           @relation(fields: [companyId], references: [id])
+
+  @@map("users")
+}
+
+model ExpenseCategory {
+  id          String    @id @default(uuid())
+  name        String
+  description String?
+  isActive    Boolean   @default(true)
+  companyId   String
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  company     Company   @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  expenses    Expense[]
+
+  @@unique([name, companyId])
+  @@map("expense_categories")
+}
+
+model Expense {
+  id               String            @id @default(cuid())
+  description      String
+  amount           Float
+  originalAmount   Float?
+  originalCurrency String?
+  exchangeRate     Float?
+  currency         String            @default("USD")
+  expenseDate      DateTime
+  receiptUrl       String?
+  merchantName     String?
+  notes            String?
+  ocrData          Json?
+  status           ExpenseStatus     @default(PENDING)
+  currentStep      Int               @default(1)
+  totalSteps       Int               @default(1)
+  submittedAt      DateTime?
+  isReadonly       Boolean           @default(false)
+  userId           String
+  companyId        String
+  categoryId       String?
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  approvals        ExpenseApproval[]
+  category         ExpenseCategory?  @relation(fields: [categoryId], references: [id])
+  company          Company           @relation(fields: [companyId], references: [id])
+  user             User              @relation(fields: [userId], references: [id])
+
+  @@map("expenses")
+}
+
+model ExpenseApproval {
+  id         String         @id @default(cuid())
+  expenseId  String
+  approverId String
+  step       Int
+  status     ApprovalStatus @default(PENDING)
+  comments   String?
+  approvedAt DateTime?
+  rejectedAt DateTime?
+  createdAt  DateTime       @default(now())
+  updatedAt  DateTime       @updatedAt
+  approver   User           @relation("ApproverExpenses", fields: [approverId], references: [id])
+  expense    Expense        @relation(fields: [expenseId], references: [id])
+
+  @@unique([expenseId, approverId])
+  @@map("expense_approvals")
+}
+
+model ApprovalRule {
+  id          String         @id @default(cuid())
+  name        String
+  description String?
+  minAmount   Float?
+  maxAmount   Float?
+  categoryIds String[]
+  isActive    Boolean        @default(true)
+  companyId   String
+  createdById String
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+  company     Company        @relation(fields: [companyId], references: [id])
+  createdBy   User           @relation("CreatedApprovalRules", fields: [createdById], references: [id])
+  steps       ApprovalStep[]
+
+  @@map("approval_rules")
+}
+
+model ApprovalStep {
+  id        String       @id @default(uuid())
+  ruleId    String
+  userId    String
+  step      Int
+  createdAt DateTime     @default(now())
+  rule      ApprovalRule @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+
+  @@unique([ruleId, step])
+  @@map("approval_steps")
 }
 
 enum UserRole {
@@ -14,7 +146,6 @@ enum UserRole {
   EMPLOYEE
 }
 
-// Enums
 enum Role {
   EMPLOYEE
   MANAGER
@@ -39,149 +170,4 @@ enum ApprovalRuleType {
   PERCENTAGE
   SPECIFIC_APPROVER
   HYBRID
-}
-
-model Company {
-  id                     String   @id @default(cuid())
-  name                   String
-  country                String   // Country where the company is located
-  currency               String   @default("USD") // Base currency for the company
-  sequentialApproval     Boolean  @default(false) // If true, approvals must be sequential
-  minimumApprovalPercent Int      @default(50) // Minimum percentage of approvers needed
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
-
-  // Relations
-  users      User[]
-  expenses   Expense[]
-  categories ExpenseCategory[]
-  rules      ApprovalRule[]
-
-  @@map("companies")
-}
-
-model User {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  name         String
-  password     String   // Hashed password
-  role         Role     @default(EMPLOYEE)
-  companyId    String
-  company      Company  @relation(fields: [companyId], references: [id])
-  isApprover   Boolean  @default(false)
-  approverLevel Int?    // For sequential approval order
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-
-  // Relations
-  expenses         Expense[]
-  approvals        ExpenseApproval[]
-  createdRules     ApprovalRule[]    @relation("CreatedApprovalRules")
-  approvedExpenses ExpenseApproval[] @relation("ApproverExpenses")
-
-  @@map("users")
-}
-
-model ExpenseCategory {
-  id          String    @id @default(uuid())
-  name        String
-  description String?
-  isActive    Boolean   @default(true)
-  companyId   String
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-
-  company     Company   @relation(fields: [companyId], references: [id], onDelete: Cascade)
-  expenses    Expense[]
-
-  @@unique([name, companyId])
-  @@map("expense_categories")
-}
-
-model Expense {
-  id               String           @id @default(cuid())
-  description      String
-  amount           Float
-  originalAmount   Float?
-  originalCurrency String?
-  exchangeRate     Float?
-  currency         String           @default("USD")
-  expenseDate      DateTime
-  receiptUrl       String?
-  merchantName     String?
-  notes            String?
-  ocrData          Json?            // Store OCR extracted data
-  status           ExpenseStatus    @default(PENDING)
-  currentStep      Int              @default(1)
-  totalSteps       Int              @default(1)
-  submittedAt      DateTime?        // When the expense was submitted
-  isReadonly       Boolean          @default(false) // Makes expense readonly after submission
-  userId           String
-  companyId        String
-  categoryId       String?
-  createdAt        DateTime         @default(now())
-  updatedAt        DateTime         @updatedAt
-
-  // Relations
-  user       User              @relation(fields: [userId], references: [id])
-  company    Company           @relation(fields: [companyId], references: [id])
-  category   ExpenseCategory?  @relation(fields: [categoryId], references: [id])
-  approvals  ExpenseApproval[]
-
-  @@map("expenses")
-}
-
-model ExpenseApproval {
-  id         String            @id @default(cuid())
-  expenseId  String
-  approverId String
-  step       Int
-  status     ApprovalStatus    @default(PENDING)
-  comments   String?
-  approvedAt DateTime?
-  rejectedAt DateTime?
-  createdAt  DateTime          @default(now())
-  updatedAt  DateTime          @updatedAt
-
-  // Relations
-  expense  Expense @relation(fields: [expenseId], references: [id])
-  approver User    @relation("ApproverExpenses", fields: [approverId], references: [id])
-  user     User    @relation(fields: [approverId], references: [id], map: "expense_approvals_user_fkey")
-
-  @@unique([expenseId, approverId])
-  @@map("expense_approvals")
-}
-
-model ApprovalRule {
-  id                  String           @id @default(cuid())
-  name                String
-  description         String?
-  minAmount           Float?
-  maxAmount           Float?
-  categoryIds         String[] // Array of category IDs
-  isActive            Boolean          @default(true)
-  companyId           String
-  createdById         String
-  createdAt           DateTime         @default(now())
-  updatedAt           DateTime         @updatedAt
-
-  // Relations
-  company             Company          @relation(fields: [companyId], references: [id])
-  createdBy           User             @relation("CreatedApprovalRules", fields: [createdById], references: [id])
-  steps               ApprovalStep[]
-
-  @@map("approval_rules")
-}
-
-model ApprovalStep {
-  id             String @id @default(uuid())
-  ruleId         String
-  userId         String
-  step           Int
-  createdAt      DateTime @default(now())
-
-  rule           ApprovalRule @relation(fields: [ruleId], references: [id], onDelete: Cascade)
-
-  @@unique([ruleId, step])
-  @@map("approval_steps")
 }


### PR DESCRIPTION
This pull request primarily refactors the Prisma schema to improve clarity and maintainability by reorganizing relation definitions, moving enums to the end of the file, and making minor adjustments to field formatting. Additionally, it updates the `.gitignore` to exclude Prisma migration files from version control.

**Prisma schema refactoring and improvements:**

* Reorganized relation fields in all models (`Company`, `User`, `ExpenseCategory`, `Expense`, `ExpenseApproval`, `ApprovalRule`, `ApprovalStep`) to group them together and improve readability. Relation definitions are now more consistent across models. [[1]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL9-R24) [[2]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL67-R43) [[3]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL93) [[4]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL113-R89) [[5]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL145-R106) [[6]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL161-L168)
* Moved all enum definitions (`UserRole`, `Role`, `ExpenseStatus`, `ApprovalStatus`, `ApprovalRuleType`) to the end of the `schema.prisma` file for better organization.
* Minor field formatting and comment cleanup across models for consistency (e.g., removed redundant comments, aligned field ordering). [[1]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL9-R24) [[2]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL67-R43) [[3]](diffhunk://#diff-c5204521fba08ada5e3186da11d0f82ac888a8675dccfee1c201ce95be5647ddL113-R89)

**Repository management:**

* Updated `.gitignore` to exclude `prisma/migrations/` from version control, preventing migration files from being tracked.